### PR TITLE
adding bash to `apk` instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ EXPOSE 5001
 EXPOSE 8080
 EXPOSE 8085
 EXPOSE 9000
-RUN apk --no-cache add openjdk11-jre && \
+RUN apk --no-cache add openjdk11-jre bash && \
     yarn global add firebase-tools@${VERSION} && \
     yarn cache clean && \
     firebase setup:emulators:database && \


### PR DESCRIPTION
Running `firebase emulators:start` fails with this output:

```
~ $ firebase emulators:start
i  emulators: Starting emulators: functions, firestore, hosting, pubsub
⚠  functions: The following emulators are not running, calls to these services from the Functions emulator will affect production: database
⚠  Your requested "node" version "8" doesn't match your global version "12"
i  firestore: Firestore Emulator logging to firestore-debug.log
i  hosting: Serving hosting files from: build
✔  hosting: Local server: http://localhost:5000
i  pubsub: Pub/Sub Emulator logging to pubsub-debug.log
⚠  pubsub: Fatal error occurred: 
   Pub/Sub Emulator has exited with code: 127, 
   stopping all running emulators
i  hub: Stopping emulator hub
i  functions: Stopping Functions Emulator
i  firestore: Stopping Firestore Emulator
i  hosting: Stopping Hosting Emulator
i  pubsub: Stopping Pub/Sub Emulator
⚠  pubsub: Error stopping Pub/Sub Emulator
```

The contents of pubs-debug.log are: 
```
env: can't execute 'bash': No such file or directory
```

Adding bash to the image fixes the problem.