### PR TITLE
Add Cloud Storage Emulator (port 9199)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,14 @@ EXPOSE 8085
 EXPOSE 9000
 EXPOSE 9005
 EXPOSE 9099
+EXPOSE 9199
 RUN apk --no-cache add openjdk11-jre bash && \
     yarn global add firebase-tools@${VERSION} && \
     yarn cache clean && \
     firebase setup:emulators:database && \
     firebase setup:emulators:firestore && \
     firebase setup:emulators:pubsub && \
+    firebase setup:emulators:storage && \
     firebase -V && \
     java -version && \
     chown -R node:node $HOME

--- a/Dockerfile.node10
+++ b/Dockerfile.node10
@@ -24,12 +24,14 @@ EXPOSE 8085
 EXPOSE 9000
 EXPOSE 9005
 EXPOSE 9099
+EXPOSE 9199
 RUN apk --no-cache add openjdk11-jre bash && \
     yarn global add firebase-tools@${VERSION} && \
     yarn cache clean && \
     firebase setup:emulators:database && \
     firebase setup:emulators:firestore && \
     firebase setup:emulators:pubsub && \
+    firebase setup:emulators:storage && \
     firebase -V && \
     java -version && \
     chown -R node:node $HOME

--- a/Dockerfile.node12
+++ b/Dockerfile.node12
@@ -24,12 +24,14 @@ EXPOSE 8085
 EXPOSE 9000
 EXPOSE 9005
 EXPOSE 9099
+EXPOSE 9199
 RUN apk --no-cache add openjdk11-jre bash && \
     yarn global add firebase-tools@${VERSION} && \
     yarn cache clean && \
     firebase setup:emulators:database && \
     firebase setup:emulators:firestore && \
     firebase setup:emulators:pubsub && \
+    firebase setup:emulators:storage && \
     firebase -V && \
     java -version && \
     chown -R node:node $HOME

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ OUT OF OR IN CONNECTION WITH THE DOCKER IMAGE OR THE USE OR OTHER DEALINGS IN TH
 | 9000 | Realtime Database |
 | 9005 | Firebase Login    |
 | 9099 | Authentication    |
+| 9199 | Cloud Storage     |
 
 ## Guides
 

--- a/doc/guide/running_firebase_emulators.md
+++ b/doc/guide/running_firebase_emulators.md
@@ -3,7 +3,7 @@ These steps assume that you have a properly configured Firebase project with run
 
 1. Start this docker image with the following command:
     ```
-    docker run -p 9099:9099 -p 9005:9005 -p 9000:9000 -p 8085:8085 -p 8080:8080 -p 5001:5001 -p 5000:5000 -p 4000:4000 -v /path/to/project:/home/node --name firebase-tools andreysenov/firebase-tools
+    docker run -p 9199:9199 -p 9099:9099 -p 9005:9005 -p 9000:9000 -p 8085:8085 -p 8080:8080 -p 5001:5001 -p 5000:5000 -p 4000:4000 -v /path/to/project:/home/node --name firebase-tools andreysenov/firebase-tools
     ```
 1. From the shell prompt running in the docker container, run `firebase init emulators` to update the `firebase.json` file in the root of your project. When asked whether you want to enable the emulator UI, choose "yes".
 1. Edit your `firebase.json` file to contain this snippet:
@@ -22,5 +22,5 @@ These steps assume that you have a properly configured Firebase project with run
 
 _**Note:** Use the following command to start the docker container AND the emulators together:_
 ```
-docker run -p 9099:9099 -p 9005:9005 -p 9000:9000 -p 8085:8085 -p 8080:8080 -p 5001:5001 -p 5000:5000 -p 4000:4000 -v /path/to/project:/home/node --name firebase-tools andreysenov/firebase-tools firebase emulators:start
+docker run -p 9199:9199 -p 9099:9099 -p 9005:9005 -p 9000:9000 -p 8085:8085 -p 8080:8080 -p 5001:5001 -p 5000:5000 -p 4000:4000 -v /path/to/project:/home/node --name firebase-tools andreysenov/firebase-tools firebase emulators:start
 ```


### PR DESCRIPTION
Initializing the new Cloud Storage emulator and exposing port 9199, which is the default port for the storage emulator. 

Forgive the multiple commits, I just made the edits using the built-in browser editor.