### PR TITLE
Build images for linux/amd64 and linux/arm64

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -4,13 +4,13 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 3 * * *'
+    - cron: "0 3 * * *"
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 env:
-  REPOSITORY: alexjball/firebase-tools
+  REPOSITORY: andreysenov/firebase-tools
   VERSION: 11.7.0
 
 jobs:
@@ -20,26 +20,14 @@ jobs:
 
     strategy:
       matrix:
-        context: [
-          {
-            dockerfile: Dockerfile,
-            node: node-lts,
-            os: alpine
-          },
-          {
-            dockerfile: Dockerfile.node16,
-            node: node-16,
-            os: alpine
-          },
-          {
-            dockerfile: Dockerfile.node14,
-            node: node-14,
-            os: alpine
-          }
-        ]
+        context:
+          [
+            { dockerfile: Dockerfile, node: node-lts, os: alpine },
+            { dockerfile: Dockerfile.node16, node: node-16, os: alpine },
+            { dockerfile: Dockerfile.node14, node: node-14, os: alpine },
+          ]
 
     steps:
-
       - name: Checkout the repository
         uses: actions/checkout@v2
 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -10,12 +10,13 @@ on:
       - '**'
 
 env:
-  REPOSITORY: andreysenov/firebase-tools
+  REPOSITORY: alexjball/firebase-tools
   VERSION: 11.7.0
 
 jobs:
   firebase-tools:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' }}
 
     strategy:
       matrix:
@@ -42,9 +43,22 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build the Docker image
         run: >
-          docker build . --no-cache --pull
+          docker buildx build . --no-cache --pull
+          --platform linux/amd64,linux/arm64
           -f ${{ matrix.context.dockerfile }}
           -t ${{ env.REPOSITORY }}:${{ env.VERSION }}-${{ matrix.context.node }}
           -t ${{ env.REPOSITORY }}:${{ env.VERSION }}-${{ matrix.context.node }}-${{ matrix.context.os }}
@@ -53,24 +67,4 @@ jobs:
           --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           --build-arg VERSION=${{ env.VERSION }}
           --build-arg VCS_REF=${{ github.sha }}
-
-      - name: Login to Docker Hub
-        if: ${{ github.event_name != 'pull_request' }}
-        run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Publish the Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          docker push ${{ env.REPOSITORY }}:${{ env.VERSION }}-${{ matrix.context.node }}
-          docker push ${{ env.REPOSITORY }}:${{ env.VERSION }}-${{ matrix.context.node }}-${{ matrix.context.os }}
-          docker push ${{ env.REPOSITORY }}:latest-${{ matrix.context.node }}
-
-      - name: Publish the Docker image (Latest)
-        if: ${{ github.event_name != 'pull_request' && matrix.context.dockerfile == 'Dockerfile' }}
-        run: |
-          docker tag ${{ env.REPOSITORY }}:${{ env.VERSION }}-${{ matrix.context.node }}-${{ matrix.context.os }} ${{ env.REPOSITORY }}:${{ env.VERSION }}
-          docker tag ${{ env.REPOSITORY }}:${{ env.VERSION }}-${{ matrix.context.node }}-${{ matrix.context.os }} ${{ env.REPOSITORY }}:latest-${{ matrix.context.os }}
-          docker tag ${{ env.REPOSITORY }}:${{ env.VERSION }}-${{ matrix.context.node }} ${{ env.REPOSITORY }}:latest
-          docker push ${{ env.REPOSITORY }}:${{ env.VERSION }}
-          docker push ${{ env.REPOSITORY }}:latest-${{ matrix.context.os }}
-          docker push ${{ env.REPOSITORY }}:latest
+          --push

--- a/Dockerfile.node16
+++ b/Dockerfile.node16
@@ -28,6 +28,7 @@ RUN apk --no-cache add openjdk11-jre bash && \
     firebase setup:emulators:firestore && \
     firebase setup:emulators:pubsub && \
     firebase setup:emulators:storage && \
+    firebase setup:emulators:ui && \
     firebase -V && \
     java -version && \
     chown -R node:node $HOME


### PR DESCRIPTION
closes #29 

I'm not familiar enough with `buildx` to know how to build and push images in separate steps, so PR builds no longer occur.
Also used docker-provided action for authentication.

Build times go from 2 min for just amd64 to 5-7 min for amd64 + arm64.

[Successful runs](https://github.com/alexjball/firebase-tools-docker/actions/workflows/default.yml)
[image](https://hub.docker.com/r/alexjball/firebase-tools)