### PR TITLE
Use Node slim instead of alpine

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -23,19 +23,19 @@ jobs:
           {
             dockerfile: Dockerfile,
             node: node-lts,
-            os: alpine,
+            os: slim,
             platforms: 'linux/amd64,linux/arm64',
           },
           {
             dockerfile: Dockerfile.node18,
             node: node-18,
-            os: alpine,
+            os: slim,
             platforms: 'linux/amd64,linux/arm64',
           },
           {
             dockerfile: Dockerfile.node16,
             node: node-16,
-            os: alpine,
+            os: slim,
             platforms: 'linux/amd64,linux/arm64',
           }
         ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:lts-slim
 ARG BUILD_DATE
 ARG VERSION
 ARG VCS_REF
@@ -21,9 +21,9 @@ EXPOSE 9000
 EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
-RUN apk --no-cache add autoconf automake bash g++ libtool make openjdk11-jre python3 && \
-    yarn global add firebase-tools@${VERSION} typescript && \
-    yarn cache clean && \
+RUN apt-get update && apt-get install -y autoconf automake bash g++ libtool make openjdk-17-jre-headless python3 && \
+    npm install -g firebase-tools@${VERSION} typescript && \
+    npm cache clean --force && \
     firebase setup:emulators:database && \
     firebase setup:emulators:firestore && \
     firebase setup:emulators:pubsub && \

--- a/Dockerfile.node16
+++ b/Dockerfile.node16
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:16-slim
 ARG BUILD_DATE
 ARG VERSION
 ARG VCS_REF
@@ -21,9 +21,9 @@ EXPOSE 9000
 EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
-RUN apk --no-cache add autoconf automake bash g++ libtool make openjdk11-jre python3 && \
-    yarn global add firebase-tools@${VERSION} typescript && \
-    yarn cache clean && \
+RUN apt-get update && apt-get install -y autoconf automake bash g++ libtool make openjdk-11-jre-headless python3 && \
+    npm install -g firebase-tools@${VERSION} typescript && \
+    npm cache clean --force && \
     firebase setup:emulators:database && \
     firebase setup:emulators:firestore && \
     firebase setup:emulators:pubsub && \

--- a/Dockerfile.node18
+++ b/Dockerfile.node18
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:18-slim
 ARG BUILD_DATE
 ARG VERSION
 ARG VCS_REF
@@ -21,9 +21,9 @@ EXPOSE 9000
 EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
-RUN apk --no-cache add autoconf automake bash g++ libtool make openjdk11-jre python3 && \
-    yarn global add firebase-tools@${VERSION} typescript && \
-    yarn cache clean && \
+RUN apt-get update && apt-get install -y autoconf automake bash g++ libtool make openjdk-17-jre-headless python3 && \
+    npm install -g firebase-tools@${VERSION} typescript && \
+    npm cache clean --force && \
     firebase setup:emulators:database && \
     firebase setup:emulators:firestore && \
     firebase setup:emulators:pubsub && \

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ OUT OF OR IN CONNECTION WITH THE DOCKER IMAGE OR THE USE OR OTHER DEALINGS IN TH
 * Firebase CLI
 * Firebase emulators
 * Node.js (from the base image)
-* OpenJDK 11
+* OpenJDK 17 (or 11 for Node 16)
 * Python 3
 * TypeScript
 * Yarn (from the base image)


### PR DESCRIPTION
There are some issue by using alpine image with pubsub: 

`Pub/Sub Emulator has exited with code: 134,`

Cf. : https://github.com/firebase/firebase-tools/issues/5256

And Node.js Alpine is an unofficial Docker container image build that is maintained by the Node.js Docker team, unofficially supported by the Node.js team.