### PR TITLE
Update images to OpenJDK 21. Java 17 was deprecated since 14.19.0 and completely not supported in 15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
 SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-17-jre-headless python3 && \
+RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-21-jre-headless python3 && \
     npm install -g firebase-tools@${VERSION} typescript && \
     npm cache clean --force && \
     firebase setup:emulators:database && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-slim
+FROM node:lts-trixie-slim
 ARG BUILD_DATE
 ARG VERSION
 ARG VCS_REF
@@ -22,10 +22,7 @@ EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
 SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y autoconf g++ libtool make python3 curl gnupg && \
-    curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /usr/share/keyrings/adoptium-archive-keyring.gpg > /dev/null && \
-    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://packages.adoptium.net/artifactory/deb bookworm main" | tee /etc/apt/sources.list.d/adoptium.list > /dev/null && \
-    apt-get update && apt-get install -y temurin-21-jre && \
+RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-21-jre-headless python3 && \
     npm install -g firebase-tools@${VERSION} typescript && \
     npm cache clean --force && \
     firebase setup:emulators:database && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,10 @@ EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
 SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-21-jre-headless python3 && \
+RUN apt-get update && apt-get install -y autoconf g++ libtool make python3 curl gnupg && \
+    curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /usr/share/keyrings/adoptium-archive-keyring.gpg > /dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://packages.adoptium.net/artifactory/deb bookworm main" | tee /etc/apt/sources.list.d/adoptium.list > /dev/null && \
+    apt-get update && apt-get install -y temurin-21-jre && \
     npm install -g firebase-tools@${VERSION} typescript && \
     npm cache clean --force && \
     firebase setup:emulators:database && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
 SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-21-jre-headless python3 && \
+RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-25-jre-headless python3 && \
     npm install -g firebase-tools@${VERSION} typescript && \
     npm cache clean --force && \
     firebase setup:emulators:database && \

--- a/Dockerfile.node20
+++ b/Dockerfile.node20
@@ -22,7 +22,7 @@ EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
 SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-17-jre-headless python3 && \
+RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-21-jre-headless python3 && \
     npm install -g firebase-tools@${VERSION} typescript && \
     npm cache clean --force && \
     firebase setup:emulators:database && \

--- a/Dockerfile.node20
+++ b/Dockerfile.node20
@@ -22,7 +22,10 @@ EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
 SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-21-jre-headless python3 && \
+RUN apt-get update && apt-get install -y autoconf g++ libtool make python3 curl gnupg && \
+    curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /usr/share/keyrings/adoptium-archive-keyring.gpg > /dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://packages.adoptium.net/artifactory/deb bookworm main" | tee /etc/apt/sources.list.d/adoptium.list > /dev/null && \
+    apt-get update && apt-get install -y temurin-21-jre && \
     npm install -g firebase-tools@${VERSION} typescript && \
     npm cache clean --force && \
     firebase setup:emulators:database && \

--- a/Dockerfile.node20
+++ b/Dockerfile.node20
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:20-trixie-slim
 ARG BUILD_DATE
 ARG VERSION
 ARG VCS_REF
@@ -22,10 +22,7 @@ EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
 SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y autoconf g++ libtool make python3 curl gnupg && \
-    curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /usr/share/keyrings/adoptium-archive-keyring.gpg > /dev/null && \
-    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://packages.adoptium.net/artifactory/deb bookworm main" | tee /etc/apt/sources.list.d/adoptium.list > /dev/null && \
-    apt-get update && apt-get install -y temurin-21-jre && \
+RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-25-jre-headless python3 && \
     npm install -g firebase-tools@${VERSION} typescript && \
     npm cache clean --force && \
     firebase setup:emulators:database && \

--- a/Dockerfile.node22
+++ b/Dockerfile.node22
@@ -22,7 +22,7 @@ EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
 SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-17-jre-headless python3 && \
+RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-21-jre-headless python3 && \
     npm install -g firebase-tools@${VERSION} typescript && \
     npm cache clean --force && \
     firebase setup:emulators:database && \

--- a/Dockerfile.node22
+++ b/Dockerfile.node22
@@ -22,7 +22,10 @@ EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
 SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-21-jre-headless python3 && \
+RUN apt-get update && apt-get install -y autoconf g++ libtool make python3 curl gnupg && \
+    curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /usr/share/keyrings/adoptium-archive-keyring.gpg > /dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://packages.adoptium.net/artifactory/deb bookworm main" | tee /etc/apt/sources.list.d/adoptium.list > /dev/null && \
+    apt-get update && apt-get install -y temurin-21-jre && \
     npm install -g firebase-tools@${VERSION} typescript && \
     npm cache clean --force && \
     firebase setup:emulators:database && \

--- a/Dockerfile.node22
+++ b/Dockerfile.node22
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:22-trixie-slim
 ARG BUILD_DATE
 ARG VERSION
 ARG VCS_REF
@@ -22,10 +22,7 @@ EXPOSE 9005
 EXPOSE 9099
 EXPOSE 9199
 SHELL ["/bin/bash", "-c"]
-RUN apt-get update && apt-get install -y autoconf g++ libtool make python3 curl gnupg && \
-    curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /usr/share/keyrings/adoptium-archive-keyring.gpg > /dev/null && \
-    echo "deb [signed-by=/usr/share/keyrings/adoptium-archive-keyring.gpg] https://packages.adoptium.net/artifactory/deb bookworm main" | tee /etc/apt/sources.list.d/adoptium.list > /dev/null && \
-    apt-get update && apt-get install -y temurin-21-jre && \
+RUN apt-get update && apt-get install -y autoconf g++ libtool make openjdk-25-jre-headless python3 && \
     npm install -g firebase-tools@${VERSION} typescript && \
     npm cache clean --force && \
     firebase setup:emulators:database && \

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ OUT OF OR IN CONNECTION WITH THE DOCKER IMAGE OR THE USE OR OTHER DEALINGS IN TH
 * Firebase CLI
 * Firebase emulators
 * Node.js (from the base image)
-* OpenJDK 17
+* OpenJDK 17 for versions lower than 14.19.0
+* OpenJDK 21 for version higher than 14.19.0 due to deprecation
 * Python 3
 * TypeScript
 * Yarn (from the base image)

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ OUT OF OR IN CONNECTION WITH THE DOCKER IMAGE OR THE USE OR OTHER DEALINGS IN TH
 * Firebase CLI
 * Firebase emulators
 * Node.js (from the base image)
-* OpenJDK 17 for versions lower than 14.19.0
-* OpenJDK 21 for version higher than 14.19.0 due to deprecation
+* OpenJDK 25
 * Python 3
 * TypeScript
 * Yarn (from the base image)


### PR DESCRIPTION
- Addresses https://github.com/AndreySenov/firebase-tools-docker/issues/49

This PR updates all images to use Java 21 and documents the requirement for Firebase Tools >= 14.19.0.

Changes:
- Dockerfile, Dockerfile.node20, Dockerfile.node22: `openjdk-17-jre-headless` -> `openjdk-21-jre-headless`
- README: Added note that Firebase Tools version 14.19.0 and newer deprecate Java 17 and for 15.0 it's hard requirement of Java 21+

Tested 15.0 and 14.27.0 for both approaches



